### PR TITLE
Fix Khronos Neutral sRGB

### DIFF
--- a/config.ocio
+++ b/config.ocio
@@ -2828,7 +2828,7 @@ colorspaces:
     isdata: false
     from_scene_reference: !<GroupTransform>
       children:
-        - !<ColorSpaceTransform> {src: cie_xyz_d65_interchange, dst: Linear Rec.709}
+        - !<ColorSpaceTransform> {src: Linear CIE-XYZ E, dst: Linear Rec.709}
         - !<AllocationTransform> {allocation: lg2, vars: [-9, 10]}
         - !<FileTransform> {src: pbrNeutral.cube, interpolation: tetrahedral}
         - !<ColorSpaceTransform> {src: Linear Rec.709, dst: sRGB}


### PR DESCRIPTION
Fix Khronos Neutral sRGB colorspace transform, which was causing formation to be broken